### PR TITLE
Usability Improvements

### DIFF
--- a/LOMV2.sln
+++ b/LOMV2.sln
@@ -3,7 +3,7 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.4.33213.308
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LOMV2", "LOMV2\LOMV2.csproj", "{FA3491CE-5EF8-40DE-8E19-218ECAEBB7A5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "LOMV2", "LOMV2\LOMV2.csproj", "{FA3491CE-5EF8-40DE-8E19-218ECAEBB7A5}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/LOMV2/Constants.cs
+++ b/LOMV2/Constants.cs
@@ -1,0 +1,7 @@
+﻿namespace LOM
+{
+    public static class Constants
+    {
+        public const string DefaultVersion = "1.1.335";
+    }
+}

--- a/LOMV2/Constants.cs
+++ b/LOMV2/Constants.cs
@@ -2,6 +2,6 @@
 {
     public static class Constants
     {
-        public const string DefaultVersion = "1.1.335";
+        public const string DefaultVersion = "1.1.338";
     }
 }

--- a/LOMV2/LOMV2.csproj
+++ b/LOMV2/LOMV2.csproj
@@ -9,8 +9,10 @@
     <RootNamespace>LOM</RootNamespace>
     <UseWindowsForms>True</UseWindowsForms>
     <ApplicationIcon>exeIcon2.ico</ApplicationIcon>
-    <Version>1.4.0</Version>
+    <Version>2.1.0</Version>
     <PackageIcon>exeIcon2.png</PackageIcon>
+    <FileVersion>2.1.0</FileVersion>
+    <AssemblyVersion>2.1.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/LOMV2/MainWindow.xaml
+++ b/LOMV2/MainWindow.xaml
@@ -79,6 +79,10 @@
                     </RowDefinition>
                     <RowDefinition Height="auto">
                     </RowDefinition>
+                    <RowDefinition Height="auto">
+                    </RowDefinition>
+                    <RowDefinition Height="auto">
+                    </RowDefinition>
                     <RowDefinition Height="*">
                     </RowDefinition>
                 </Grid.RowDefinitions>
@@ -90,10 +94,11 @@
                 <Button Style="{DynamicResource RoundButton}" Grid.Column="1" Grid.Row="1" Click="Remove_Button_Click">Remove</Button>
                 <Button Style="{DynamicResource RoundButton}" Grid.Column="1" Grid.Row="2" Click="Enable_All_Button_Click">Enable All</Button>
                 <Button Style="{DynamicResource RoundButton}" Grid.Column="1" Grid.Row="3" Click="Disable_All_Button_Click">Disable All</Button>
-                <Button Style="{DynamicResource RoundButton}" Grid.Column="1" Grid.Row="4" Click="Apply">Apply</Button>
                 <Label Grid.Row="5" Grid.ColumnSpan="99" Content="Game Version:"/>
                 <TextBox x:Name="VersionTextBox" Grid.Row="6" MaxHeight="20" Grid.ColumnSpan="2" TextChanged="VersionTextBox_TextChanged" VerticalAlignment="Top"/>
-                <Button Click="Start_Game_Button_Click" Style="{StaticResource RoundButton}" Grid.ColumnSpan="2" Grid.Row="7" MinHeight="130" MinWidth="130" MaxHeight="130" MaxWidth="130" VerticalAlignment="Bottom" Margin="0,0,0,5">
+                <Button Style="{DynamicResource RoundButton}" Grid.Column="0" Grid.Row="7" Grid.ColumnSpan="2" Click="Apply">Apply</Button>
+                <Button Style="{DynamicResource RoundButton}" Grid.Column="0" Grid.Row="8" Grid.ColumnSpan="2" Click="ApplyAndStart">Apply and Start Game</Button>
+                <Button Click="Start_Game_Button_Click" Style="{StaticResource RoundButton}" Grid.ColumnSpan="2" Grid.Row="9" MinHeight="130" MinWidth="130" MaxHeight="130" MaxWidth="130" VerticalAlignment="Bottom" Margin="0,0,0,5">
                     Start Game
                 </Button>
             </Grid>

--- a/LOMV2/MainWindow.xaml
+++ b/LOMV2/MainWindow.xaml
@@ -83,14 +83,16 @@
                     </RowDefinition>
                 </Grid.RowDefinitions>
                 <Button Style="{DynamicResource RoundButton}" Grid.Column="0" Grid.ColumnSpan="2" Click="Refresh_Button_Click" Margin="0,25,0,0" >Refresh</Button>
-                <Button Style="{DynamicResource RoundButton}" Grid.Column="0" Grid.Row="1" Click="Upp_Button_Click">Up</Button>
-                <Button Style="{DynamicResource RoundButton}" Grid.Column="0" Grid.Row="2" Click="Down_Button_Click">Down</Button>
-                <Button Style="{DynamicResource RoundButton}" Grid.Column="0" Grid.Row="3" Click="Apply">Apply</Button>
-                <Button Style="{DynamicResource RoundButton}" Grid.Column="0" Grid.Row="4" Click="Remove_Button_Click">Remove</Button>
+                <Button Style="{DynamicResource RoundButton}" Grid.Column="0" Grid.Row="1" Click="ToTop_Button_Click">To Top</Button>
+                <Button Style="{DynamicResource RoundButton}" Grid.Column="0" Grid.Row="2" Click="Up_Button_Click">Up</Button>
+                <Button Style="{DynamicResource RoundButton}" Grid.Column="0" Grid.Row="3" Click="Down_Button_Click">Down</Button>
+                <Button Style="{DynamicResource RoundButton}" Grid.Column="0" Grid.Row="4" Click="ToBottom_Button_Click">To Bottom</Button>
+                <Button Style="{DynamicResource RoundButton}" Grid.Column="1" Grid.Row="1" Click="Remove_Button_Click">Remove</Button>
                 <Button Style="{DynamicResource RoundButton}" Grid.Column="1" Grid.Row="2" Click="Enable_All_Button_Click">Enable All</Button>
                 <Button Style="{DynamicResource RoundButton}" Grid.Column="1" Grid.Row="3" Click="Disable_All_Button_Click">Disable All</Button>
+                <Button Style="{DynamicResource RoundButton}" Grid.Column="1" Grid.Row="4" Click="Apply">Apply</Button>
                 <Label Grid.Row="5" Grid.ColumnSpan="99" Content="Game Version:"/>
-                <TextBox x:Name="VersionTextBox" Grid.Row="6" MaxHeight="20" Grid.ColumnSpan="2" Text="1.1.328" TextChanged="VersionTextBox_TextChanged" VerticalAlignment="Top"/>
+                <TextBox x:Name="VersionTextBox" Grid.Row="6" MaxHeight="20" Grid.ColumnSpan="2" TextChanged="VersionTextBox_TextChanged" VerticalAlignment="Top"/>
                 <Button Click="Start_Game_Button_Click" Style="{StaticResource RoundButton}" Grid.ColumnSpan="2" Grid.Row="7" MinHeight="130" MinWidth="130" MaxHeight="130" MaxWidth="130" VerticalAlignment="Bottom" Margin="0,0,0,5">
                     Start Game
                 </Button>
@@ -108,6 +110,16 @@
                   CanUserDeleteRows="False"
                   CanUserReorderColumns="False"
                   PreviewTextInput="ModItemDataGrid_PreviewTextInput" Margin="2,0,2,0">
+                <DataGrid.ContextMenu>
+                    <ContextMenu>
+                        <MenuItem Header="To Top" Click="ToTop_Button_Click" />
+                        <MenuItem Header="Up Five" Click="UpFive_Button_Click" />
+                        <MenuItem Header="Up One" Click="Up_Button_Click" />
+                        <MenuItem Header="Down One" Click="Down_Button_Click" />
+                        <MenuItem Header="Down Five" Click="DownFive_Button_Click" />
+                        <MenuItem Header="To Bottom" Click="ToBottom_Button_Click" />
+                    </ContextMenu>
+                </DataGrid.ContextMenu>
                 <DataGrid.RowStyle>
                     <Style TargetType="DataGridRow">
                         <Style.Triggers>
@@ -131,7 +143,7 @@
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
-                    <DataGridTextColumn Header="Load Order" Binding="{Binding DefaultLoadOrder}" CanUserSort="False" IsReadOnly="True"/>
+                    <DataGridTextColumn Header="Load Order" Binding="{Binding DefaultLoadOrder}" CanUserSort="False" IsReadOnly="False"/>
                     <DataGridTextColumn Header="Display Name" Binding="{Binding DisplayName}" CanUserSort="False" IsReadOnly="True"/>
                     <DataGridTextColumn Header="Author" Binding="{Binding Author}" CanUserSort="False" IsReadOnly="True"/>
                     <DataGridTextColumn Header="Folder" Binding="{Binding FolderNameShort}" CanUserSort="False" IsReadOnly="True"/>
@@ -141,9 +153,23 @@
             <TabControl Grid.Column="2" Grid.Row="1">
                 <TabItem Header="Presets">
                     <DockPanel>
-                        <Button Click="Save_Preset_Button_Click" DockPanel.Dock="Top" Style="{StaticResource RoundButton}" Content="Save Preset"/>
-                        <Button Click="Load_Preset_Button_Click" DockPanel.Dock="Top" Style="{StaticResource RoundButton}" Content="Load Preset"/>
-                        <Button Click="Remove_Preset_Button_Click" DockPanel.Dock="Top" Style="{StaticResource RoundButton}" Content="Remove Preset"/>
+                        <Grid DockPanel.Dock="Top">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*"/>
+                                <ColumnDefinition Width="*"/>
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="auto"/>
+                                <RowDefinition Height="auto"/>
+                                <RowDefinition Height="auto"/>
+                                <RowDefinition Height="auto"/>
+                            </Grid.RowDefinitions>
+                            <Button Style="{DynamicResource RoundButton}" Grid.Column="0" Grid.Row="1" Click="Save_Preset_Button_Click">Save Preset</Button>
+                            <Button Style="{DynamicResource RoundButton}" Grid.Column="0" Grid.Row="2" Click="Load_Preset_Button_Click">Load Preset</Button>
+                            <Button Style="{DynamicResource RoundButton}" Grid.Column="0" Grid.Row="3" Click="Remove_Preset_Button_Click">Delete Preset</Button>
+                            <Button Style="{DynamicResource RoundButton}" Grid.Column="1" Grid.Row="1" Click="Copy_Preset_To_Clipboard_Button_Click">Export Preset to Clipboard</Button>
+                            <Button Style="{DynamicResource RoundButton}" Grid.Column="1" Grid.Row="2" Click="Paste_Preset_From_Clipboard_Button_Click">Import Preset from Clipboard</Button>
+                        </Grid>
                         <ListBox ItemsSource="{Binding PresetNames}" DockPanel.Dock="Top" x:Name="PresetListBox" MinHeight="120" Margin="5,0,5,0"/>
                     </DockPanel>
                 </TabItem>

--- a/LOMV2/MainWindow.xaml.cs
+++ b/LOMV2/MainWindow.xaml.cs
@@ -222,6 +222,12 @@ public partial class MainWindow : Window
         _systemIO.WriteModsModDotJson(mods);
     }
 
+    private void ApplyAndStart(object sender, RoutedEventArgs e)
+    {
+        Apply(sender, e);
+        Start_Game_Button_Click(sender, e);
+    }
+
     private void RefreshMods()
     {
         var mods = GenerateModListFromMainPath(ViewModel.MainModsFolder);

--- a/LOMV2/MainWindow.xaml.cs
+++ b/LOMV2/MainWindow.xaml.cs
@@ -27,6 +27,8 @@ public partial class MainWindow : Window
     public MainWindowViewModel ViewModel { get; set; } = new();
     private ISystemIO _systemIO { get; set; }
 
+    private bool _updatingCell = false;
+
     private System.Timers.Timer _resizeTimer = new(100) { Enabled = false };
 
     public MainWindow(ISystemIO systemIO)
@@ -38,6 +40,7 @@ public partial class MainWindow : Window
 
         ModItemDataGrid.DataContext = ViewModel;
 
+        this.VersionTextBox.Text = Constants.DefaultVersion;
         LoadSystemSettings();
 
         _resizeTimer.Elapsed += ResizeTimerElapsed;
@@ -78,17 +81,70 @@ public partial class MainWindow : Window
         Debug.WriteLine(String.Join("\n", ViewModel.ModInfos.Select(x => $"{x.DisplayName} | {x.DefaultLoadOrder}")));
     }
 
-    private async void Upp_Button_Click(object sender, RoutedEventArgs e)
+    private async void Up_Button_Click(object sender, RoutedEventArgs e)
     {
         MoveSelectedItem(-1);
 
         Debug.WriteLine(String.Join("\n", ViewModel.ModInfos.Select(x => $"{x.DisplayName} | {x.DefaultLoadOrder}")));
+    }
 
+    private async void UpFive_Button_Click(object sender, RoutedEventArgs e)
+    {
+        var delta = -5;
+        if (ModItemDataGrid.SelectedIndex + delta < 1)
+        {
+            delta = -ModItemDataGrid.SelectedIndex;
+        }
+
+        MoveSelectedItem(delta);
+
+        Debug.WriteLine(String.Join("\n", ViewModel.ModInfos.Select(x => $"{x.DisplayName} | {x.DefaultLoadOrder}")));
+    }
+
+    private async void DownFive_Button_Click(object sender, RoutedEventArgs e)
+    {
+        var delta = 5;
+        if (ModItemDataGrid.SelectedIndex + delta >= this.ModItemDataGrid.Items.Count)
+        {
+            delta = ModItemDataGrid.Items.Count - ModItemDataGrid.SelectedIndex - 1;
+        }
+
+        MoveSelectedItem(delta);
+
+        Debug.WriteLine(String.Join("\n", ViewModel.ModInfos.Select(x => $"{x.DisplayName} | {x.DefaultLoadOrder}")));
     }
 
     private async void Down_Button_Click(object sender, RoutedEventArgs e)
     {
         MoveSelectedItem(1);
+
+        Debug.WriteLine(String.Join("\n", ViewModel.ModInfos.Select(x => $"{x.DisplayName} | {x.DefaultLoadOrder}")));
+    }
+
+    private async void ToTop_Button_Click(object sender, RoutedEventArgs e)
+    {
+        var selectedItem = ModItemDataGrid.SelectedItem as ModInfo;
+
+        if (selectedItem == null)
+            return;
+
+        var oldIndex = ViewModel.ModInfos.IndexOf(selectedItem);
+
+        MoveSelectedItem(-oldIndex);
+
+        Debug.WriteLine(String.Join("\n", ViewModel.ModInfos.Select(x => $"{x.DisplayName} | {x.DefaultLoadOrder}")));
+    }
+
+    private async void ToBottom_Button_Click(object sender, RoutedEventArgs e)
+    {
+        var selectedItem = ModItemDataGrid.SelectedItem as ModInfo;
+
+        if (selectedItem == null)
+            return;
+
+        var oldIndex = ViewModel.ModInfos.IndexOf(selectedItem);
+
+        MoveSelectedItem(ModItemDataGrid.Items.Count - oldIndex - 1);
 
         Debug.WriteLine(String.Join("\n", ViewModel.ModInfos.Select(x => $"{x.DisplayName} | {x.DefaultLoadOrder}")));
     }
@@ -159,7 +215,7 @@ public partial class MainWindow : Window
         var version = VersionTextBox.Text;
         if (string.IsNullOrEmpty(version))
         {
-            version = "1.1.328";
+            version = Constants.DefaultVersion;
         }
 
         _systemIO.WriteModListDotJson(mods, ViewModel.MainModsFolder, version);
@@ -288,8 +344,41 @@ public partial class MainWindow : Window
 
     private void ModItemDataGrid_SelectedCellsChanged(object sender, SelectedCellsChangedEventArgs e)
     {
-        ViewModel.OnPropertyChanged(nameof(ViewModel.SelectedModLabel));
-        ViewModel.OnPropertyChanged(nameof(ViewModel.SelectedMod));
+        if (!this._updatingCell)
+        {
+            _updatingCell = true;
+            ViewModel.OnPropertyChanged(nameof(ViewModel.SelectedModLabel));
+            ViewModel.OnPropertyChanged(nameof(ViewModel.SelectedMod));
+
+            // Spaghetti code to detect mods that are out of order...can't rely on the current selected item always...
+            for (var i = 0; i < this.ModItemDataGrid.Items.Count; i++)
+            {
+                var item = this.ModItemDataGrid.Items[i] as ModInfo;
+                var index = Convert.ToInt32(item.DefaultLoadOrder);
+                var currentIndex = i + 1;
+
+                if (index != currentIndex)
+                {
+                    if (index < 1)
+                    {
+                        index = 1;
+                    }
+                    else if (index > this.ModItemDataGrid.Items.Count)
+                    {
+                        index = this.ModItemDataGrid.Items.Count;
+                    }
+
+                    var deltaIndex = index - currentIndex;
+
+                    this.ModItemDataGrid.SelectedIndex = currentIndex - 1;
+                    item.DefaultLoadOrder = currentIndex;
+                    MoveSelectedItem(deltaIndex);
+                    break;
+                }
+            }
+
+            _updatingCell = false;
+        }
     }
 
     private void Overriding_ListBox_Selected(object sender, SelectionChangedEventArgs e)
@@ -432,8 +521,6 @@ public partial class MainWindow : Window
 
     private void PersistSystemSettings()
     {
-        var systemFolder = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-
         int windowX = 0;
         int windowY = 0;
         System.Windows.Application.Current.Dispatcher.Invoke(() =>
@@ -442,39 +529,59 @@ public partial class MainWindow : Window
             windowY = (int)this.Height;
         });
 
-        var systemSettings = new SystemSettingsDto() {
-            MainModsFolder = ViewModel.MainModsFolder,
-            ModSources = ViewModel.ModSources.ToList(),
-            Presets = ViewModel.Presets,
-            WindowX = ((int?)windowX) ?? 1050,
-            WindowY = ((int?)windowY) ?? 500,
-            Vender = ViewModel.Vender,
-            ExEPath = ViewModel.ExEPath,
-            GameVersion = this.VersionTextBox.Text,
-        };
-
-        if (!Directory.Exists($"{systemFolder}\\LOMV2"))
-            Directory.CreateDirectory($"{systemFolder}\\LOMV2");
-
-        File.WriteAllText($"{systemFolder}\\LOMV2\\settings.json", JsonSerializer.Serialize(systemSettings));
+        this.Dispatcher.Invoke(() =>
+        {
+            var systemSettings = new SystemSettingsDto()
+                                 {
+                                     MainModsFolder = ViewModel.MainModsFolder,
+                                     ModSources = ViewModel.ModSources.ToList(),
+                                     WindowX = ((int?)windowX) ?? 1050,
+                                     WindowY = ((int?)windowY) ?? 500,
+                                     Vender = ViewModel.Vender,
+                                     ExEPath = ViewModel.ExEPath,
+                                     GameVersion = this.VersionTextBox.Text,
+                                 };
+            
+            if (!Directory.Exists(LoadOrderManagerFolder))
+                Directory.CreateDirectory(LoadOrderManagerFolder);
+            
+            File.WriteAllText(Path.Combine(LoadOrderManagerFolder, "settings.json"), JsonSerializer.Serialize(systemSettings));
+            
+            // recursively write each preset to its own file to make sharing easier
+            foreach (var preset in ViewModel.Presets)
+            {
+                File.WriteAllText(Path.Combine(LoadOrderManagerFolder, $"{preset.Key}.txt"), preset.Value);
+            }
+        });
     }
+
+    public string LoadOrderManagerFolder => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "LOMV2");
 
     private void LoadSystemSettings()
     {
-        var systemFolder = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
+        var settingsFile = Path.Combine(LoadOrderManagerFolder, "settings.json");
 
-        if (!File.Exists($"{systemFolder}\\LOMV2\\settings.json"))
+        if (!File.Exists(settingsFile))
             return;
 
         try
         {
-            var systemSettingsJson = File.ReadAllText($"{systemFolder}\\LOMV2\\settings.json");
+            var systemSettingsJson = File.ReadAllText(settingsFile);
             SystemSettingsDto systemSettings = JsonSerializer.Deserialize<SystemSettingsDto>(systemSettingsJson);
             ViewModel.ModSources = systemSettings.ModSources.ToHashSet();
             ViewModel.MainModsFolder = systemSettings.MainModsFolder;
-            ViewModel.Presets = systemSettings.Presets;
             ViewModel.Vender = systemSettings.Vender;
             ViewModel.ExEPath = systemSettings.ExEPath;
+            ViewModel.Presets = systemSettings.Presets; // kept for backwards compatibility
+            foreach (var file in Directory.GetFiles(LoadOrderManagerFolder))
+            {
+                // any file aside from the settings file is a preset
+                if (file != settingsFile)
+                {
+                    var presetName = Path.GetFileNameWithoutExtension(file);
+                    ViewModel.Presets.Add(presetName, File.ReadAllText(file));
+                }
+            }
 
             this.Dispatcher.Invoke(() =>
             {
@@ -510,13 +617,13 @@ public partial class MainWindow : Window
         RefreshMods();
     }
 
-    private void SavePreset(string presetName)
+    private void SavePreset(string presetName, string presetValue = "")
     {
         if (ViewModel.Presets.ContainsKey(presetName))
             if (MessageBox.Show($"Preset name {presetName} allready in use,\ndo you want to override?", "", MessageBoxButton.YesNo) == MessageBoxResult.No)
                 return;
-
-        ViewModel.Presets[presetName] = JsonSerializer.Serialize(ViewModel.ModInfos.ToArray());
+        
+        ViewModel.Presets[presetName] = string.IsNullOrWhiteSpace(presetValue) ? GetPresetStringForCurrentMods() : presetValue;
 
         ViewModel.OnPropertyChanged(nameof(ViewModel.Presets));
         ViewModel.OnPropertyChanged(nameof(ViewModel.PresetNames));
@@ -524,12 +631,21 @@ public partial class MainWindow : Window
         PersistSystemSettings();
     }
 
+    private string GetPresetStringForCurrentMods()
+    {
+        var modInfos = ViewModel.ModInfos.ToArray();
+
+        var presetKeys = modInfos.Select(x => new PresetModInfo(x.DisplayName, x.Author, x.FolderNameShort, x.Enabled, x.DefaultLoadOrder)).ToArray();
+
+        return JsonSerializer.Serialize(presetKeys);
+    }
+
     private void LoadPreset(string presetName)
     {
         if (!ViewModel.Presets.TryGetValue(presetName, out string presetJson))
             return;
 
-        var presetMods = JsonSerializer.Deserialize<List<ModInfo>>(presetJson);
+        var presetMods = JsonSerializer.Deserialize<List<PresetModInfo>>(presetJson);
 
         if (presetMods == null)
             return;
@@ -541,7 +657,7 @@ public partial class MainWindow : Window
         {
             var match = presetMods.FirstOrDefault(presetMod => presetMod.DisplayName == mod.DisplayName &&
                 presetMod.Author == mod.Author &&
-                presetMod.FolderNameShort == mod.FolderNameShort);
+                presetMod.FolderShort == mod.FolderNameShort);
 
             if (match == null)
             {
@@ -550,7 +666,7 @@ public partial class MainWindow : Window
             }
 
             mod.Enabled = match.Enabled;
-            mod.DefaultLoadOrder = match.DefaultLoadOrder;
+            mod.DefaultLoadOrder = match.LoadOrder;
         });
 
         mods = SortAndUpdateMods(mods);
@@ -560,6 +676,10 @@ public partial class MainWindow : Window
     private void RemovePreset(string presetName)
     {
         ViewModel.Presets.Remove(presetName);
+        if (File.Exists(Path.Combine(LoadOrderManagerFolder, $"{presetName}.txt")))
+        {
+            File.Delete(Path.Combine(LoadOrderManagerFolder, $"{presetName}.txt"));
+        }
         PersistSystemSettings();
 
         ViewModel.OnPropertyChanged(nameof(ViewModel.Presets));
@@ -597,6 +717,34 @@ public partial class MainWindow : Window
             return;
 
         RemovePreset(selectedPreset);
+    }
+
+    public void Copy_Preset_To_Clipboard_Button_Click(object sender, RoutedEventArgs e)
+    {
+        var selectedPreset = PresetListBox.SelectedItem as string;
+        if (selectedPreset == null)
+            return;
+
+        Clipboard.SetText($"{selectedPreset}:{GetPresetStringForCurrentMods()}");
+    }
+
+    public void Paste_Preset_From_Clipboard_Button_Click(object sender, RoutedEventArgs e)
+    {
+        var clipboardValue = Clipboard.GetText();
+        if (!string.IsNullOrEmpty(clipboardValue))
+        {
+            try
+            {
+                var presetText = clipboardValue.Split(":", 2);
+
+                SavePreset(presetText[0], presetText[1]);
+                LoadPreset(presetText[0]);
+            }
+            catch (Exception _)
+            {
+                // swallow the failure for now
+            }
+        }
     }
 
     public void Remove_Secondary_Folder_Button_Click(Object sender, RoutedEventArgs e)

--- a/LOMV2/Models/ModInfo.cs
+++ b/LOMV2/Models/ModInfo.cs
@@ -8,7 +8,7 @@ using System.Text.Json.Serialization;
 public class ModInfo : ICloneable
 {
     public Mod? Mod {get ;set;} = new Mod();
-    public string? FolderName {get ;set;}
+    public string? FolderName {get ;set; }
 
     [JsonIgnore]
     public string? FolderNameShort { get => FolderName.Split("\\").TakeLast(1).First(); }

--- a/LOMV2/Models/PresetModInfo.cs
+++ b/LOMV2/Models/PresetModInfo.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Text.Json.Serialization;
+
+namespace LOM.Models
+{
+    class PresetModInfo
+    {
+        public string DisplayName { get; set; }
+
+        public string Author { get; set; }
+
+        public string FolderShort { get; set; }
+
+        public bool Enabled { get; set; }
+
+        public double? LoadOrder { get; set; }
+
+        public PresetModInfo(string displayName, string author, string folderShort, bool enabled, double? loadOrder)
+        {
+            this.DisplayName = displayName;
+            this.Author = author;
+            this.FolderShort = folderShort;
+            this.Enabled = enabled;
+            this.LoadOrder = loadOrder;
+        }
+    }
+}

--- a/LOMV2/Models/SystemSettingsDto.cs
+++ b/LOMV2/Models/SystemSettingsDto.cs
@@ -17,6 +17,6 @@ namespace LOM.Models
         public int WindowY { get; set; } = 500;
         public Vender Vender { get; set; } = Vender.None;
         public string ExEPath { get; set; } = string.Empty;
-        public string GameVersion { get; set; } = "1.1.335";
+        public string GameVersion { get; set; } = Constants.DefaultVersion;
     }
 }

--- a/LOMV2/Services/ISystemIO.cs
+++ b/LOMV2/Services/ISystemIO.cs
@@ -11,7 +11,7 @@ namespace LOM.Services
         List<FileInfo> ScanFolder(string path);
         bool IsMainModsFolder (string path);
         bool IsMainModsFolder (List<FileInfo> files);
-        void WriteModListDotJson(List<ModInfo> modInfos, string path, string version = "1.1.328");
+        void WriteModListDotJson(List<ModInfo> modInfos, string path, string version = Constants.DefaultVersion);
         void WriteModsModDotJson(List<ModInfo> modInfos);
         bool RemoveMod(ModInfo mod);
         bool InsertDirectory(string source, string target);

--- a/LOMV2/Services/SystemIO.cs
+++ b/LOMV2/Services/SystemIO.cs
@@ -55,7 +55,7 @@ namespace LOM.Services
             return mods.First();
         }
 
-        public void WriteModListDotJson(List<ModInfo> modInfos, string path, string version = "1.1.328")
+        public void WriteModListDotJson(List<ModInfo> modInfos, string path, string version = Constants.DefaultVersion)
         {
             if (string.IsNullOrEmpty(path))
                 return;


### PR DESCRIPTION
Improved user experience (hopefully :) )

- Default GameVersion is moved to a constants file, to make it easier to update in the future
- Added ToTop/Bottom buttons for moving mods to the top or bottom of the load order
- Added context menu allowing right-clicking to move mods
- Editable load order position cell in the datagrid
- Presets reworked to _not_ store all the data about mods and only what is needed
- Presets are now stored in separate files from the rest of the settings, allowing them to be more easily shared (same directory as settings though)
- Export/Import preset from clipboard functionality
- Moved Apply button
- Added Apply and Start Game button

New look of the UI:
![image](https://user-images.githubusercontent.com/10594450/222520794-f38cfda2-653a-4338-b137-38e4f39b881e.png)

Example of the new preset file structure:
![image](https://user-images.githubusercontent.com/10594450/222521083-30850212-26ae-4f9f-bfe6-971b9889fdcb.png)

Preset File Size Difference ("WarNeverChanges" is the old structure of how a preset was saved, but in a separate file from the settings.json):
![image](https://user-images.githubusercontent.com/10594450/222535605-eb934dd4-5c71-4e22-836c-893474c64aee.png)
